### PR TITLE
Fix radial chart data key

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -29,7 +29,7 @@ const chartConfig = {
 } satisfies ChartConfig;
 
 export const Chart = ({ used = 0 }: { used: number }) => {
-  const chartData = [{ storage: "used", 10: used, fill: "white" }];
+  const chartData = [{ storage: "used", value: used, fill: "white" }];
 
   return (
     <Card className="chart">
@@ -49,7 +49,7 @@ export const Chart = ({ used = 0 }: { used: number }) => {
               className="polar-grid"
               polarRadius={[86, 74]}
             />
-            <RadialBar dataKey="storage" background cornerRadius={10} />
+            <RadialBar dataKey="value" background cornerRadius={10} />
             <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
               <Label
                 content={({ viewBox }) => {


### PR DESCRIPTION
## Summary
- use descriptive `value` key for radial chart dataset
- update `RadialBar` to use `value`

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6840cca33704832d9b3f70b02117620b