### PR TITLE
Update error messages in file actions

### DIFF
--- a/lib/actions/file.actions.ts
+++ b/lib/actions/file.actions.ts
@@ -164,7 +164,7 @@ export const updateFileUsers = async ({
     revalidatePath(path);
     return parseStringify(updatedFile);
   } catch (error) {
-    handleError(error, "Failed to rename file");
+    handleError(error, "Failed to update file users");
   }
 };
 
@@ -189,7 +189,7 @@ export const deleteFile = async ({
     revalidatePath(path);
     return parseStringify({ status: "success" });
   } catch (error) {
-    handleError(error, "Failed to rename file");
+    handleError(error, "Failed to delete file");
   }
 };
 


### PR DESCRIPTION
## Summary
- fix error messages in `updateFileUsers` and `deleteFile`

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6840cca4a2a0832db4581ae757db3433