### PR TITLE
Update README Next.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ StoreIt is a modern, full-stack file storage application built with Next.js and 
 ## Tech Stack
 
 ### Frontend
-- **Next.js 14**: React framework with App Router for server-side rendering and routing
+- **Next.js 15**: React framework with App Router for server-side rendering and routing
 - **TypeScript**: Type-safe code development
 - **Tailwind CSS**: Utility-first CSS framework for styling
 - **Shadcn UI**: Reusable UI components built with Radix UI


### PR DESCRIPTION
## Summary
- update Tech Stack documentation with Next.js 15

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6840cca5e3bc832d896badca5bf04fdd