### PR TITLE
Add Vitest and initial utility tests

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { convertFileSize } from '../utils';
+
+describe('convertFileSize', () => {
+  it('returns bytes for values under 1 KB', () => {
+    expect(convertFileSize(500)).toBe('500 Bytes');
+  });
+
+  it('converts bytes to KB', () => {
+    expect(convertFileSize(1024)).toBe('1.0 KB');
+    expect(convertFileSize(1536)).toBe('1.5 KB');
+  });
+
+  it('converts bytes to MB', () => {
+    const bytes = 2 * 1024 * 1024;
+    expect(convertFileSize(bytes)).toBe('2.0 MB');
+  });
+
+  it('converts bytes to GB', () => {
+    const bytes = 3 * 1024 * 1024 * 1024;
+    expect(convertFileSize(bytes)).toBe('3.0 GB');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -47,6 +49,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "vitest": "^1.6.0",
     "eslint": "^8",
     "eslint-config-next": "15.0.2",
     "eslint-config-prettier": "^9.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});
+


### PR DESCRIPTION
## Summary
- configure Vitest for testing
- add tests for `convertFileSize`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cca701b4832d98319cc939ad7700