### PR TITLE
Add global drag drop

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Sidebar from "@/components/Sidebar";
 import MobileNavigation from "@/components/MobileNavigation";
 import Header from "@/components/Header";
+import PageDropzone from "@/components/PageDropzone";
 import { getCurrentUser } from "@/lib/actions/user.actions";
 import { redirect } from "next/navigation";
 import { Toaster } from "@/components/ui/toaster";
@@ -14,17 +15,19 @@ const Layout = async ({ children }: { children: React.ReactNode }) => {
   if (!currentUser) return redirect("/sign-in");
 
   return (
-    <main className="flex h-screen">
-      <Sidebar {...currentUser} />
+    <PageDropzone ownerId={currentUser.$id} accountId={currentUser.accountId}>
+      <main className="flex h-screen">
+        <Sidebar {...currentUser} />
 
-      <section className="flex h-full flex-1 flex-col">
-        <MobileNavigation {...currentUser} />
-        <Header userId={currentUser.$id} accountId={currentUser.accountId} />
-        <div className="main-content">{children}</div>
-      </section>
+        <section className="flex h-full flex-1 flex-col">
+          <MobileNavigation {...currentUser} />
+          <Header userId={currentUser.$id} accountId={currentUser.accountId} />
+          <div className="main-content">{children}</div>
+        </section>
 
-      <Toaster />
-    </main>
+        <Toaster />
+      </main>
+    </PageDropzone>
   );
 };
 export default Layout;

--- a/app/globals.css
+++ b/app/globals.css
@@ -354,6 +354,14 @@
     @apply subtitle-2 mb-2 line-clamp-1 max-w-[300px] !important;
   }
 
+  /* Page Dropzone */
+  .dropzone-wrapper {
+    @apply relative min-h-screen;
+  }
+  .dropzone-overlay {
+    @apply fixed inset-0 z-40 flex flex-col items-center justify-center gap-4 border-2 border-dashed border-brand bg-black/60 !important;
+  }
+
   .error-toast {
     @apply bg-red !rounded-[10px] !important;
   }

--- a/components/PageDropzone.tsx
+++ b/components/PageDropzone.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import { useDropzone } from "react-dropzone";
+import Image from "next/image";
+import Thumbnail from "@/components/Thumbnail";
+import { convertFileToUrl, getFileType } from "@/lib/utils";
+import { uploadFile } from "@/lib/actions/file.actions";
+import { useToast } from "@/hooks/use-toast";
+import { MAX_FILE_SIZE } from "@/constants";
+import { usePathname } from "next/navigation";
+
+interface PageDropzoneProps {
+  ownerId: string;
+  accountId: string;
+  children: React.ReactNode;
+}
+
+const PageDropzone = ({ ownerId, accountId, children }: PageDropzoneProps) => {
+  const path = usePathname();
+  const { toast } = useToast();
+  const [files, setFiles] = useState<File[]>([]);
+
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      setFiles(acceptedFiles);
+
+      const uploadPromises = acceptedFiles.map(async (file) => {
+        if (file.size > MAX_FILE_SIZE) {
+          setFiles((prevFiles) => prevFiles.filter((f) => f.name !== file.name));
+
+          return toast({
+            description: (
+              <p className="body-2 text-white">
+                <span className="font-semibold">{file.name}</span> is too large.
+                Max file size is 50MB.
+              </p>
+            ),
+            className: "error-toast",
+          });
+        }
+
+        return uploadFile({ file, ownerId, accountId, path }).then((uploadedFile) => {
+          if (uploadedFile) {
+            setFiles((prevFiles) => prevFiles.filter((f) => f.name !== file.name));
+          }
+        });
+      });
+
+      await Promise.all(uploadPromises);
+    },
+    [ownerId, accountId, path],
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    noClick: true,
+    noKeyboard: true,
+  });
+
+  const handleRemoveFile = (
+    e: React.MouseEvent<HTMLImageElement, MouseEvent>,
+    fileName: string,
+  ) => {
+    e.stopPropagation();
+    setFiles((prevFiles) => prevFiles.filter((file) => file.name !== fileName));
+  };
+
+  return (
+    <div {...getRootProps()} className="dropzone-wrapper">
+      <input {...getInputProps()} />
+      {isDragActive && (
+        <div className="dropzone-overlay">
+          <Image
+            src="/assets/icons/upload.svg"
+            alt="upload"
+            width={40}
+            height={40}
+          />
+          <p className="h3 text-white">Drop files to upload</p>
+        </div>
+      )}
+      {children}
+      {files.length > 0 && (
+        <ul className="uploader-preview-list">
+          <h4 className="h4 text-light-100">Uploading</h4>
+
+          {files.map((file, index) => {
+            const { type, extension } = getFileType(file.name);
+
+            return (
+              <li
+                key={`${file.name}-${index}`}
+                className="uploader-preview-item"
+              >
+                <div className="flex items-center gap-3">
+                  <Thumbnail
+                    type={type}
+                    extension={extension}
+                    url={convertFileToUrl(file)}
+                  />
+
+                  <div className="preview-item-name">
+                    {file.name}
+                    <Image
+                      src="/assets/icons/file-loader.gif"
+                      width={80}
+                      height={26}
+                      alt="Loader"
+                    />
+                  </div>
+                </div>
+
+                <Image
+                  src="/assets/icons/remove.svg"
+                  width={24}
+                  height={24}
+                  alt="Remove"
+                  onClick={(e) => handleRemoveFile(e, file.name)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default PageDropzone;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,6 +48,12 @@ declare interface FileUploaderProps {
   className?: string;
 }
 
+declare interface PageDropzoneProps {
+  ownerId: string;
+  accountId: string;
+  children: React.ReactNode;
+}
+
 declare interface MobileNavigationProps {
   ownerId: string;
   accountId: string;


### PR DESCRIPTION
## Summary
- create `PageDropzone` wrapper to handle drag and drop anywhere on the page
- style the overlay
- wrap authenticated layout with the new dropzone
- update type declarations

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6840ce521a5c832d953933559b2c48a1