### PR TITLE
Add media viewer and persistent login

### DIFF
--- a/app/(root)/[type]/page.tsx
+++ b/app/(root)/[type]/page.tsx
@@ -3,6 +3,7 @@ import Sort from "@/components/Sort";
 import { getFiles } from "@/lib/actions/file.actions";
 import { Models } from "node-appwrite";
 import Card from "@/components/Card";
+import { FileViewerProvider } from "@/components/FileViewerProvider";
 import { getFileTypesParams } from "@/lib/utils";
 
 const Page = async ({ searchParams, params }: SearchParamProps) => {
@@ -15,6 +16,7 @@ const Page = async ({ searchParams, params }: SearchParamProps) => {
   const files = await getFiles({ types, searchText, sort });
 
   return (
+    <FileViewerProvider files={files.documents}>
     <div className="page-container">
       <section className="w-full">
         <h1 className="h1 capitalize">{type}</h1>
@@ -35,14 +37,15 @@ const Page = async ({ searchParams, params }: SearchParamProps) => {
       {/* Render the files */}
       {files.total > 0 ? (
         <section className="file-list">
-          {files.documents.map((file: Models.Document) => (
-            <Card key={file.$id} file={file} />
+          {files.documents.map((file: Models.Document, i) => (
+            <Card key={file.$id} file={file} index={i} />
           ))}
         </section>
       ) : (
         <p className="empty-list">No files uploaded</p>
       )}
     </div>
+    </FileViewerProvider>
   );
 };
 

--- a/app/(root)/file/[id]/page.tsx
+++ b/app/(root)/file/[id]/page.tsx
@@ -1,0 +1,24 @@
+import FileViewer from "@/components/FileViewer";
+import { getFiles } from "@/lib/actions/file.actions";
+import { redirect } from "next/navigation";
+
+const Page = async ({ params }: { params: { id: string } }) => {
+  const files = await getFiles({ types: [] });
+  const index = files.documents.findIndex((f: any) => f.$id === params.id);
+
+  if (index === -1) redirect("/");
+
+  const file = files.documents[index];
+  const prevId = index > 0 ? files.documents[index - 1].$id : null;
+  const nextId =
+    index < files.documents.length - 1 ? files.documents[index + 1].$id : null;
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <h2 className="p-4 text-center text-xl font-semibold">{file.name}</h2>
+      <FileViewer file={file} prevId={prevId} nextId={nextId} />
+    </div>
+  );
+};
+
+export default Page;

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -6,6 +6,7 @@ import PageDropzone from "@/components/PageDropzone";
 import { getCurrentUser } from "@/lib/actions/user.actions";
 import { redirect } from "next/navigation";
 import { Toaster } from "@/components/ui/toaster";
+import { UserProvider } from "@/contexts/UserContext";
 
 export const dynamic = "force-dynamic";
 
@@ -15,19 +16,24 @@ const Layout = async ({ children }: { children: React.ReactNode }) => {
   if (!currentUser) return redirect("/sign-in");
 
   return (
-    <PageDropzone ownerId={currentUser.$id} accountId={currentUser.accountId}>
-      <main className="flex h-screen">
-        <Sidebar {...currentUser} />
+    <UserProvider initialUser={currentUser}>
+      <PageDropzone ownerId={currentUser.$id} accountId={currentUser.accountId}>
+        <main className="flex h-screen">
+          <Sidebar />
 
-        <section className="flex h-full flex-1 flex-col">
-          <MobileNavigation {...currentUser} />
-          <Header userId={currentUser.$id} accountId={currentUser.accountId} />
-          <div className="main-content">{children}</div>
-        </section>
+          <section className="flex h-full flex-1 flex-col">
+            <MobileNavigation {...currentUser} />
+            <Header
+              userId={currentUser.$id}
+              accountId={currentUser.accountId}
+            />
+            <div className="main-content">{children}</div>
+          </section>
 
-        <Toaster />
-      </main>
-    </PageDropzone>
+          <Toaster />
+        </main>
+      </PageDropzone>
+    </UserProvider>
   );
 };
 export default Layout;

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -30,33 +30,34 @@ const Dashboard = async () => {
         {/* Uploaded file type summaries */}
         <ul className="dashboard-summary-list">
           {usageSummary.map((summary) => (
-            <Link
-              href={summary.url}
-              key={summary.title}
-              className="dashboard-summary-card"
-            >
-              <div className="space-y-4">
-                <div className="flex justify-between gap-3">
-                  <Image
-                    src={summary.icon}
-                    width={100}
-                    height={100}
-                    alt="uploaded image"
-                    className="summary-type-icon"
-                  />
-                  <h4 className="summary-type-size">
-                    {convertFileSize(summary.size) || 0}
-                  </h4>
-                </div>
+            <li key={summary.title} className="dashboard-summary-card">
+              <Link
+                href={summary.url}
+                className="dashboard-summary-link"
+              >
+                <div className="space-y-4">
+                  <div className="flex justify-between gap-3">
+                    <Image
+                      src={summary.icon}
+                      width={100}
+                      height={100}
+                      alt="uploaded image"
+                      className="summary-type-icon"
+                    />
+                    <h4 className="summary-type-size">
+                      {convertFileSize(summary.size) || 0}
+                    </h4>
+                  </div>
 
-                <h5 className="summary-type-title">{summary.title}</h5>
-                <Separator className="bg-light-400" />
-                <FormattedDateTime
-                  date={summary.latestDate}
-                  className="text-center"
-                />
-              </div>
-            </Link>
+                  <h5 className="summary-type-title">{summary.title}</h5>
+                  <Separator className="bg-light-400" />
+                  <FormattedDateTime
+                    date={summary.latestDate}
+                    className="text-center"
+                  />
+                </div>
+              </Link>
+            </li>
           ))}
         </ul>
       </section>
@@ -66,7 +67,7 @@ const Dashboard = async () => {
         <h2 className="h3 xl:h2 text-light-100">Recent files uploaded</h2>
         {files.documents.length > 0 ? (
           <ul className="mt-5 flex flex-col gap-5">
-            {files.documents.map((file: Models.Document, i) => (
+            {files.documents.map((file: Models.Document, i: number) => (
               <li key={file.$id}>
                 <RecentFileRow file={file} index={i} />
               </li>

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -66,8 +66,7 @@ const Dashboard = async () => {
           <ul className="mt-5 flex flex-col gap-5">
             {files.documents.map((file: Models.Document) => (
               <Link
-                href={file.url}
-                target="_blank"
+                href={`/file/${file.$id}`}
                 className="flex items-center gap-3"
                 key={file.$id}
               >

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -2,7 +2,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { Models } from "node-appwrite";
 
-import ActionDropdown from "@/components/ActionDropdown";
+import RecentFileRow from "@/components/RecentFileRow";
+import { FileViewerProvider } from "@/components/FileViewerProvider";
 import { Chart } from "@/components/Chart";
 import { FormattedDateTime } from "@/components/FormattedDateTime";
 import { Thumbnail } from "@/components/Thumbnail";
@@ -21,6 +22,7 @@ const Dashboard = async () => {
   const usageSummary = getUsageSummary(totalSpace);
 
   return (
+    <FileViewerProvider files={files.documents}>
     <div className="dashboard-container">
       <section>
         <Chart used={totalSpace.used} />
@@ -64,29 +66,10 @@ const Dashboard = async () => {
         <h2 className="h3 xl:h2 text-light-100">Recent files uploaded</h2>
         {files.documents.length > 0 ? (
           <ul className="mt-5 flex flex-col gap-5">
-            {files.documents.map((file: Models.Document) => (
-              <Link
-                href={`/file/${file.$id}`}
-                className="flex items-center gap-3"
-                key={file.$id}
-              >
-                <Thumbnail
-                  type={file.type}
-                  extension={file.extension}
-                  url={file.url}
-                />
-
-                <div className="recent-file-details">
-                  <div className="flex flex-col gap-1">
-                    <p className="recent-file-name">{file.name}</p>
-                    <FormattedDateTime
-                      date={file.$createdAt}
-                      className="caption"
-                    />
-                  </div>
-                  <ActionDropdown file={file} />
-                </div>
-              </Link>
+            {files.documents.map((file: Models.Document, i) => (
+              <li key={file.$id}>
+                <RecentFileRow file={file} index={i} />
+              </li>
             ))}
           </ul>
         ) : (
@@ -94,6 +77,7 @@ const Dashboard = async () => {
         )}
       </section>
     </div>
+    </FileViewerProvider>
   );
 };
 

--- a/app/(root)/profile/page.tsx
+++ b/app/(root)/profile/page.tsx
@@ -13,7 +13,7 @@ const ProfilePage = async () => {
         <h1 className="h1">Profile Settings</h1>
 
         <div className="mt-8">
-          <ProfileForm user={currentUser} />
+          <ProfileForm />
         </div>
       </section>
     </div>

--- a/app/(root)/profile/page.tsx
+++ b/app/(root)/profile/page.tsx
@@ -1,0 +1,23 @@
+import { getCurrentUser } from "@/lib/actions/user.actions";
+import { redirect } from "next/navigation";
+import ProfileForm from "@/components/ProfileForm";
+
+const ProfilePage = async () => {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser) return redirect("/sign-in");
+
+  return (
+    <div className="page-container">
+      <section className="w-full">
+        <h1 className="h1">Profile Settings</h1>
+
+        <div className="mt-8">
+          <ProfileForm user={currentUser} />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/app/globals.css
+++ b/app/globals.css
@@ -198,6 +198,14 @@
     @apply invert-0 opacity-100 !important;
   }
 
+  /* Profile icon specific styling */
+  .profile-icon {
+    @apply w-8 h-8 text-gray-400 -ml-1 !important;
+  }
+  .profile-icon-active {
+    @apply w-8 h-8 text-white -ml-1 !important;
+  }
+
   /* =====  STYLE CLASSES */
 
   /* Root Layout */

--- a/app/globals.css
+++ b/app/globals.css
@@ -431,9 +431,15 @@
   }
 
   @keyframes sidebarItemHover {
-    0% { transform: translateX(0px); }
-    50% { transform: translateX(5px); }
-    100% { transform: translateX(0px); }
+    0% {
+      transform: translateX(0px);
+    }
+    50% {
+      transform: translateX(5px);
+    }
+    100% {
+      transform: translateX(0px);
+    }
   }
 
   .sidebar-nav-item {
@@ -443,14 +449,14 @@
     animation: sidebarItemHover 0.5s ease-in-out;
     background-color: rgba(77, 156, 255, 0.1);
   }
-  
+
   /* Only change text color on hover */
   .sidebar-nav-item:not(.shad-active):hover p {
-    color: #4D9CFF !important;
+    color: #4d9cff !important;
   }
-  
+
   .sidebar-nav-item:not(.shad-active):hover {
-    color: #4D9CFF !important;
+    color: #4d9cff !important;
   }
   .sidebar-user-info {
     @apply mt-4 flex items-center justify-center gap-2 rounded-full bg-brand/10 p-1 text-light-100 lg:justify-start lg:p-3 !important;

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,13 +1,25 @@
 import { Models } from "node-appwrite";
-import Link from "next/link";
 import Thumbnail from "@/components/Thumbnail";
 import { convertFileSize } from "@/lib/utils";
 import FormattedDateTime from "@/components/FormattedDateTime";
 import ActionDropdown from "@/components/ActionDropdown";
+import { useFileViewer } from "@/components/FileViewerProvider";
 
-const Card = ({ file }: { file: Models.Document }) => {
+"use client";
+interface Props {
+  file: Models.Document;
+  index: number;
+}
+
+const Card = ({ file, index }: Props) => {
+  const { open } = useFileViewer();
+
   return (
-    <Link href={`/file/${file.$id}`} className="file-card">
+    <button
+      type="button"
+      onClick={() => open(index)}
+      className="file-card text-left"
+    >
       <div className="flex justify-between">
         <Thumbnail
           type={file.type}
@@ -33,7 +45,7 @@ const Card = ({ file }: { file: Models.Document }) => {
           By: {file.owner.fullName}
         </p>
       </div>
-    </Link>
+    </button>
   );
 };
 export default Card;

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -7,7 +7,7 @@ import ActionDropdown from "@/components/ActionDropdown";
 
 const Card = ({ file }: { file: Models.Document }) => {
   return (
-    <Link href={file.url} target="_blank" className="file-card">
+    <Link href={`/file/${file.$id}`} className="file-card">
       <div className="flex justify-between">
         <Thumbnail
           type={file.type}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Models } from "node-appwrite";
 import Thumbnail from "@/components/Thumbnail";
 import { convertFileSize } from "@/lib/utils";
@@ -5,7 +7,6 @@ import FormattedDateTime from "@/components/FormattedDateTime";
 import ActionDropdown from "@/components/ActionDropdown";
 import { useFileViewer } from "@/components/FileViewerProvider";
 
-"use client";
 interface Props {
   file: Models.Document;
   index: number;

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -2,22 +2,27 @@
 
 import { Models } from "node-appwrite";
 import { useRouter } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
 
 interface Props {
   file: Models.Document;
   prevId?: string | null;
   nextId?: string | null;
+  onPrev?: () => void;
+  onNext?: () => void;
+  onClose?: () => void;
 }
 
-const FileViewer = ({ file, prevId, nextId }: Props) => {
+const FileViewer = ({ file, prevId, nextId, onPrev, onNext, onClose }: Props) => {
   const router = useRouter();
 
   const handlePrev = () => {
+    if (onPrev) return onPrev();
     if (prevId) router.push(`/file/${prevId}`);
   };
 
   const handleNext = () => {
+    if (onNext) return onNext();
     if (nextId) router.push(`/file/${nextId}`);
   };
 
@@ -42,9 +47,12 @@ const FileViewer = ({ file, prevId, nextId }: Props) => {
     return <iframe src={file.url} className="w-full h-[80vh]" />;
   };
 
+  const showPrev = onPrev || prevId;
+  const showNext = onNext || nextId;
+
   return (
     <div className="relative flex items-center justify-center p-4">
-      {prevId && (
+      {showPrev && (
         <button
           onClick={handlePrev}
           className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
@@ -53,12 +61,20 @@ const FileViewer = ({ file, prevId, nextId }: Props) => {
         </button>
       )}
       {renderContent()}
-      {nextId && (
+      {showNext && (
         <button
           onClick={handleNext}
           className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
         >
           <ChevronRight className="size-6" />
+        </button>
+      )}
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="absolute right-2 top-2 rounded-full bg-black/60 p-1 text-white"
+        >
+          <X className="size-5" />
         </button>
       )}
     </div>

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -13,7 +13,14 @@ interface Props {
   onClose?: () => void;
 }
 
-const FileViewer = ({ file, prevId, nextId, onPrev, onNext, onClose }: Props) => {
+const FileViewer = ({
+  file,
+  prevId,
+  nextId,
+  onPrev,
+  onNext,
+  onClose,
+}: Props) => {
   const router = useRouter();
 
   const handlePrev = () => {
@@ -30,53 +37,84 @@ const FileViewer = ({ file, prevId, nextId, onPrev, onNext, onClose }: Props) =>
     if (file.type === "image" && file.extension !== "svg") {
       return (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={file.url} alt={file.name} className="max-h-[80vh] mx-auto" />
+        <img
+          src={file.url}
+          alt={file.name}
+          className="max-h-[80vh] max-w-full object-contain"
+        />
       );
     }
 
     if (file.type === "video") {
       return (
-        <video src={file.url} controls className="max-h-[80vh] mx-auto" />
+        <video src={file.url} controls className="max-h-[80vh] max-w-full" />
       );
     }
 
     if (file.type === "audio") {
-      return <audio src={file.url} controls className="mx-auto" />;
+      return <audio src={file.url} controls className="w-full max-w-md" />;
     }
 
-    return <iframe src={file.url} className="w-full h-[80vh]" />;
+    return (
+      <iframe
+        src={file.url}
+        title={file.name}
+        className="w-full h-[80vh] max-w-4xl"
+      />
+    );
   };
 
   const showPrev = onPrev || prevId;
   const showNext = onNext || nextId;
 
   return (
-    <div className="relative flex items-center justify-center p-4">
-      {showPrev && (
-        <button
-          onClick={handlePrev}
-          className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
-        >
-          <ChevronLeft className="size-6" />
-        </button>
-      )}
-      {renderContent()}
-      {showNext && (
-        <button
-          onClick={handleNext}
-          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
-        >
-          <ChevronRight className="size-6" />
-        </button>
-      )}
+    <div className="relative w-full h-full flex flex-col">
+      {/* Close button - positioned at the top right, outside the media area */}
       {onClose && (
-        <button
-          onClick={onClose}
-          className="absolute right-2 top-2 rounded-full bg-black/60 p-1 text-white"
-        >
-          <X className="size-5" />
-        </button>
+        <div className="absolute top-4 right-4 z-10">
+          <button
+            onClick={onClose}
+            aria-label="Close viewer"
+            className="rounded-full bg-black/70 p-2 text-white hover:bg-black/80 transition-colors"
+          >
+            <X className="size-6" />
+          </button>
+        </div>
       )}
+
+      {/* Main content area with navigation */}
+      <div className="flex-1 flex items-center justify-center min-h-0">
+        {/* Previous button - positioned on the left side */}
+        {showPrev && (
+          <div className="absolute left-4 top-1/2 -translate-y-1/2 z-10">
+            <button
+              onClick={handlePrev}
+              aria-label="Previous file"
+              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 transition-colors shadow-lg"
+            >
+              <ChevronLeft className="size-8" />
+            </button>
+          </div>
+        )}
+
+        {/* Media content - centered with padding to avoid overlap */}
+        <div className="flex items-center justify-center w-full h-full px-16 py-12 sm:px-20 sm:py-16">
+          {renderContent()}
+        </div>
+
+        {/* Next button - positioned on the right side */}
+        {showNext && (
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 z-10">
+            <button
+              onClick={handleNext}
+              aria-label="Next file"
+              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 transition-colors shadow-lg"
+            >
+              <ChevronRight className="size-8" />
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -2,7 +2,9 @@
 
 import { Models } from "node-appwrite";
 import { useRouter } from "next/navigation";
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { RxCross2 } from "react-icons/rx";
+import { FaAngleLeft, FaAngleRight } from "react-icons/fa6";
+import { useState, useEffect } from "react";
 
 interface Props {
   file: Models.Document;
@@ -22,15 +24,35 @@ const FileViewer = ({
   onClose,
 }: Props) => {
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [contentKey, setContentKey] = useState(0);
 
-  const handlePrev = () => {
-    if (onPrev) return onPrev();
-    if (prevId) router.push(`/file/${prevId}`);
+  useEffect(() => {
+    // Reset loading state and trigger content animation when file changes
+    setIsLoading(false);
+    setContentKey((prev) => prev + 1);
+  }, [file.$id]);
+
+  const handlePrev = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    // Small delay for smooth transition
+    setTimeout(() => {
+      if (onPrev) return onPrev();
+      if (prevId) router.push(`/file/${prevId}`);
+    }, 150);
   };
 
-  const handleNext = () => {
-    if (onNext) return onNext();
-    if (nextId) router.push(`/file/${nextId}`);
+  const handleNext = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    // Small delay for smooth transition
+    setTimeout(() => {
+      if (onNext) return onNext();
+      if (nextId) router.push(`/file/${nextId}`);
+    }, 150);
   };
 
   const renderContent = () => {
@@ -38,28 +60,54 @@ const FileViewer = ({
       return (
         // eslint-disable-next-line @next/next/no-img-element
         <img
+          key={contentKey}
           src={file.url}
           alt={file.name}
-          className="max-h-[80vh] max-w-full object-contain"
+          className={`max-h-[90vh] max-w-full object-contain transition-all duration-500 ease-out ${
+            isLoading ? "opacity-0 scale-95" : "opacity-100 scale-100"
+          }`}
+          onLoad={() => setIsLoading(false)}
         />
       );
     }
 
     if (file.type === "video") {
       return (
-        <video src={file.url} controls className="max-h-[80vh] max-w-full" />
+        <video
+          key={contentKey}
+          src={file.url}
+          controls
+          className={`max-h-[90vh] max-w-full w-full transition-all duration-500 ease-out ${
+            isLoading ? "opacity-0 scale-95" : "opacity-100 scale-100"
+          }`}
+          onLoadedData={() => setIsLoading(false)}
+        />
       );
     }
 
     if (file.type === "audio") {
-      return <audio src={file.url} controls className="w-full max-w-md" />;
+      return (
+        <audio
+          key={contentKey}
+          src={file.url}
+          controls
+          className={`w-full max-w-md transition-all duration-500 ease-out ${
+            isLoading ? "opacity-0 scale-95" : "opacity-100 scale-100"
+          }`}
+          onLoadedData={() => setIsLoading(false)}
+        />
+      );
     }
 
     return (
       <iframe
+        key={contentKey}
         src={file.url}
         title={file.name}
-        className="w-full h-[80vh] max-w-4xl"
+        className={`w-full h-full max-w-full max-h-full transition-all duration-500 ease-out ${
+          isLoading ? "opacity-0 scale-95" : "opacity-100 scale-100"
+        }`}
+        onLoad={() => setIsLoading(false)}
       />
     );
   };
@@ -68,16 +116,16 @@ const FileViewer = ({
   const showNext = onNext || nextId;
 
   return (
-    <div className="relative w-full h-full flex flex-col">
+    <div className="relative w-full h-full flex flex-col animate-in fade-in duration-300">
       {/* Close button - positioned at the top right, outside the media area */}
       {onClose && (
-        <div className="absolute top-4 right-4 z-10">
+        <div className="absolute top-4 right-4 z-10 animate-in slide-in-from-top-2 duration-300">
           <button
             onClick={onClose}
             aria-label="Close viewer"
-            className="rounded-full bg-black/70 p-2 text-white hover:bg-black/80 transition-colors"
+            className="rounded-full bg-black/70 p-2 text-white hover:bg-black/80 hover:scale-110 transition-all duration-200 backdrop-blur-sm"
           >
-            <X className="size-6" />
+            <RxCross2 className="size-6" />
           </button>
         </div>
       )}
@@ -86,35 +134,46 @@ const FileViewer = ({
       <div className="flex-1 flex items-center justify-center min-h-0">
         {/* Previous button - positioned on the left side */}
         {showPrev && (
-          <div className="absolute left-4 top-1/2 -translate-y-1/2 z-10">
+          <div className="absolute left-4 top-1/2 -translate-y-1/2 z-10 animate-in slide-in-from-left-2 duration-300">
             <button
               onClick={handlePrev}
+              disabled={isLoading}
               aria-label="Previous file"
-              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 transition-colors shadow-lg"
+              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 hover:scale-110 transition-all duration-200 shadow-lg backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <ChevronLeft className="size-8" />
+              <FaAngleLeft className="size-8" />
             </button>
           </div>
         )}
 
-        {/* Media content - centered with padding to avoid overlap */}
-        <div className="flex items-center justify-center w-full h-full px-16 py-12 sm:px-20 sm:py-16">
-          {renderContent()}
+        {/* Media content - centered with minimal padding to avoid overlap */}
+        <div className="flex items-center justify-center w-full h-full px-20 py-4">
+          <div className="w-full h-full flex items-center justify-center animate-in fade-in zoom-in-95 duration-500 ease-out">
+            {renderContent()}
+          </div>
         </div>
 
         {/* Next button - positioned on the right side */}
         {showNext && (
-          <div className="absolute right-4 top-1/2 -translate-y-1/2 z-10">
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 z-10 animate-in slide-in-from-right-2 duration-300">
             <button
               onClick={handleNext}
+              disabled={isLoading}
               aria-label="Next file"
-              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 transition-colors shadow-lg"
+              className="rounded-full bg-black/70 p-3 text-white hover:bg-black/80 hover:scale-110 transition-all duration-200 shadow-lg backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <ChevronRight className="size-8" />
+              <FaAngleRight className="size-8" />
             </button>
           </div>
         )}
       </div>
+
+      {/* Loading overlay for smooth transitions */}
+      {isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/20 backdrop-blur-sm animate-in fade-in duration-200">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Models } from "node-appwrite";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface Props {
+  file: Models.Document;
+  prevId?: string | null;
+  nextId?: string | null;
+}
+
+const FileViewer = ({ file, prevId, nextId }: Props) => {
+  const router = useRouter();
+
+  const handlePrev = () => {
+    if (prevId) router.push(`/file/${prevId}`);
+  };
+
+  const handleNext = () => {
+    if (nextId) router.push(`/file/${nextId}`);
+  };
+
+  const renderContent = () => {
+    if (file.type === "image" && file.extension !== "svg") {
+      return (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={file.url} alt={file.name} className="max-h-[80vh] mx-auto" />
+      );
+    }
+
+    if (file.type === "video") {
+      return (
+        <video src={file.url} controls className="max-h-[80vh] mx-auto" />
+      );
+    }
+
+    if (file.type === "audio") {
+      return <audio src={file.url} controls className="mx-auto" />;
+    }
+
+    return <iframe src={file.url} className="w-full h-[80vh]" />;
+  };
+
+  return (
+    <div className="relative flex items-center justify-center p-4">
+      {prevId && (
+        <button
+          onClick={handlePrev}
+          className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
+        >
+          <ChevronLeft className="size-6" />
+        </button>
+      )}
+      {renderContent()}
+      {nextId && (
+        <button
+          onClick={handleNext}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white"
+        >
+          <ChevronRight className="size-6" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default FileViewer;

--- a/components/FileViewerProvider.tsx
+++ b/components/FileViewerProvider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+import { Models } from "node-appwrite";
+import FileViewer from "@/components/FileViewer";
+
+interface Context {
+  open: (index: number) => void;
+}
+
+const FileViewerContext = createContext<Context | null>(null);
+
+export const FileViewerProvider = ({
+  files,
+  children,
+}: {
+  files: Models.Document[];
+  children: React.ReactNode;
+}) => {
+  const [index, setIndex] = useState<number | null>(null);
+
+  const close = () => setIndex(null);
+  const open = (i: number) => setIndex(i);
+  const prev = () =>
+    setIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+  const next = () =>
+    setIndex((i) => (i !== null && i < files.length - 1 ? i + 1 : i));
+
+  return (
+    <FileViewerContext.Provider value={{ open }}>
+      {children}
+      {index !== null && (
+        <div className="fixed inset-0 z-50" onClick={close}>
+          <div
+            className="absolute inset-0 bg-black/80"
+            aria-hidden="true"
+          />
+          <div
+            className="absolute inset-0 flex items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <FileViewer
+              file={files[index]}
+              onPrev={index > 0 ? prev : undefined}
+              onNext={index < files.length - 1 ? next : undefined}
+              onClose={close}
+            />
+          </div>
+        </div>
+      )}
+    </FileViewerContext.Provider>
+  );
+};
+
+export const useFileViewer = () => {
+  const ctx = useContext(FileViewerContext);
+  if (!ctx) throw new Error("useFileViewer must be used within FileViewerProvider");
+  return ctx;
+};

--- a/components/FileViewerProvider.tsx
+++ b/components/FileViewerProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useEffect } from "react";
 import { Models } from "node-appwrite";
 import FileViewer from "@/components/FileViewer";
 
@@ -18,21 +18,83 @@ export const FileViewerProvider = ({
   children: React.ReactNode;
 }) => {
   const [index, setIndex] = useState<number | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
 
-  const close = () => setIndex(null);
-  const open = (i: number) => setIndex(i);
-  const prev = () => setIndex((i) => (i !== null && i > 0 ? i - 1 : i));
-  const next = () =>
+  const close = () => {
+    if (isAnimating) return;
+    setIsAnimating(true);
+    setIsVisible(false);
+    // Wait for exit animation to complete before removing from DOM
+    setTimeout(() => {
+      setIndex(null);
+      setIsAnimating(false);
+    }, 300);
+  };
+
+  const open = (i: number) => {
+    if (isAnimating) return;
+    setIndex(i);
+    setIsAnimating(true);
+    // Small delay to ensure DOM is ready before showing animation
+    requestAnimationFrame(() => {
+      setIsVisible(true);
+      setTimeout(() => setIsAnimating(false), 300);
+    });
+  };
+
+  const prev = () => {
+    if (isAnimating) return;
+    setIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+  };
+
+  const next = () => {
+    if (isAnimating) return;
     setIndex((i) => (i !== null && i < files.length - 1 ? i + 1 : i));
+  };
+
+  // Handle escape key to close
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && index !== null) {
+        close();
+      }
+    };
+
+    if (index !== null) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden"; // Prevent background scroll
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [index]);
 
   return (
     <FileViewerContext.Provider value={{ open }}>
       {children}
       {index !== null && (
-        <div className="fixed inset-0 z-50" onClick={close}>
-          <div className="absolute inset-0 bg-black/80" aria-hidden="true" />
+        <div
+          className={`fixed inset-0 z-50 transition-all duration-300 ease-out ${
+            isVisible ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          {/* Background overlay - clicking closes the modal */}
           <div
-            className="absolute inset-0 flex items-center justify-center p-4"
+            className={`absolute inset-0 bg-black/80 backdrop-blur-sm transition-all duration-300 ease-out ${
+              isVisible ? "opacity-100" : "opacity-0"
+            }`}
+            onClick={close}
+            aria-hidden="true"
+          />
+
+          {/* Modal content */}
+          <div
+            className={`absolute inset-0 flex items-center justify-center p-4 transition-all duration-300 ease-out ${
+              isVisible ? "scale-100 opacity-100" : "scale-95 opacity-0"
+            }`}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="w-full h-full max-w-7xl max-h-full">

--- a/components/FileViewerProvider.tsx
+++ b/components/FileViewerProvider.tsx
@@ -21,8 +21,7 @@ export const FileViewerProvider = ({
 
   const close = () => setIndex(null);
   const open = (i: number) => setIndex(i);
-  const prev = () =>
-    setIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+  const prev = () => setIndex((i) => (i !== null && i > 0 ? i - 1 : i));
   const next = () =>
     setIndex((i) => (i !== null && i < files.length - 1 ? i + 1 : i));
 
@@ -31,20 +30,19 @@ export const FileViewerProvider = ({
       {children}
       {index !== null && (
         <div className="fixed inset-0 z-50" onClick={close}>
+          <div className="absolute inset-0 bg-black/80" aria-hidden="true" />
           <div
-            className="absolute inset-0 bg-black/80"
-            aria-hidden="true"
-          />
-          <div
-            className="absolute inset-0 flex items-center justify-center"
+            className="absolute inset-0 flex items-center justify-center p-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <FileViewer
-              file={files[index]}
-              onPrev={index > 0 ? prev : undefined}
-              onNext={index < files.length - 1 ? next : undefined}
-              onClose={close}
-            />
+            <div className="w-full h-full max-w-7xl max-h-full">
+              <FileViewer
+                file={files[index]}
+                onPrev={index > 0 ? prev : undefined}
+                onNext={index < files.length - 1 ? next : undefined}
+                onClose={close}
+              />
+            </div>
           </div>
         </div>
       )}
@@ -54,6 +52,7 @@ export const FileViewerProvider = ({
 
 export const useFileViewer = () => {
   const ctx = useContext(FileViewerContext);
-  if (!ctx) throw new Error("useFileViewer must be used within FileViewerProvider");
+  if (!ctx)
+    throw new Error("useFileViewer must be used within FileViewerProvider");
   return ctx;
 };

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { Button } from "@/components/ui/button";
-import Image from "next/image";
 import Search from "@/components/Search";
 import FileUploader from "@/components/FileUploader";
-import { signOutUser } from "@/lib/actions/user.actions";
+import SignOutButton from "@/components/SignOutButton";
 
 const Header = ({
   userId,
@@ -17,23 +15,7 @@ const Header = ({
       <Search />
       <div className="header-wrapper">
         <FileUploader ownerId={userId} accountId={accountId} />
-        <form
-          action={async () => {
-            "use server";
-
-            await signOutUser();
-          }}
-        >
-          <Button type="submit" className="sign-out-button">
-            <Image
-              src="/assets/icons/logout.svg"
-              alt="logo"
-              width={24}
-              height={24}
-              className="w-6"
-            />
-          </Button>
-        </form>
+        <SignOutButton className="sign-out-button" />
       </div>
     </header>
   );

--- a/components/MobileNavigation.tsx
+++ b/components/MobileNavigation.tsx
@@ -71,7 +71,7 @@ const MobileNavigation = ({
             <Separator className="mb-4 bg-light-200/20" />
           </SheetTitle>
 
-          <OptimizedNavigation 
+          <OptimizedNavigation
             className="mobile-nav"
             onItemClick={() => setOpen(false)}
           />
@@ -79,7 +79,11 @@ const MobileNavigation = ({
           <Separator className="my-5 bg-light-200/20" />
 
           <div className="flex flex-col justify-between gap-5 pb-5">
-            <FileUploader ownerId={ownerId} accountId={accountId} />
+            <FileUploader
+              ownerId={ownerId}
+              accountId={accountId}
+              className="w-full"
+            />
             <Button
               type="button"
               className="mobile-sign-out-button"

--- a/components/MobileNavigation.tsx
+++ b/components/MobileNavigation.tsx
@@ -81,9 +81,14 @@ const MobileNavigation = ({
           <div className="flex flex-col justify-between gap-5 pb-5">
             <FileUploader ownerId={ownerId} accountId={accountId} />
             <Button
-              type="submit"
+              type="button"
               className="mobile-sign-out-button"
-              onClick={async () => await signOutUser()}
+              onClick={async () => {
+                if (typeof window !== "undefined") {
+                  localStorage.removeItem("loggedIn");
+                }
+                await signOutUser();
+              }}
             >
               <OptimizedIcon
                 src="/assets/icons/logout.svg"

--- a/components/OTPModal.tsx
+++ b/components/OTPModal.tsx
@@ -44,7 +44,12 @@ const OtpModal = ({
 
       console.log({ sessionId });
 
-      if (sessionId) router.push("/");
+      if (sessionId) {
+        if (typeof window !== "undefined") {
+          localStorage.setItem("loggedIn", "true");
+        }
+        router.push("/");
+      }
     } catch (error) {
       console.log("Failed to verify OTP", error);
     }

--- a/components/OptimizedIcon.tsx
+++ b/components/OptimizedIcon.tsx
@@ -1,36 +1,41 @@
-import React from 'react';
-import Image, { ImageProps, StaticImageData } from 'next/image';
+import React from "react";
+import Image, { ImageProps, StaticImageData } from "next/image";
 
 // Import all SVG icons statically
-import dashboardIcon from '../public/assets/icons/dashboard.svg';
-import documentsIcon from '../public/assets/icons/documents.svg';
-import imagesIcon from '../public/assets/icons/images.svg';
-import videoIcon from '../public/assets/icons/video.svg';
-import othersIcon from '../public/assets/icons/others.svg';
-import logoutIcon from '../public/assets/icons/logout.svg';
-import menuIcon from '../public/assets/icons/menu.svg';
+import dashboardIcon from "../public/assets/icons/dashboard.svg";
+import documentsIcon from "../public/assets/icons/documents.svg";
+import imagesIcon from "../public/assets/icons/images.svg";
+import videoIcon from "../public/assets/icons/video.svg";
+import othersIcon from "../public/assets/icons/others.svg";
+import logoutIcon from "../public/assets/icons/logout.svg";
+import menuIcon from "../public/assets/icons/menu.svg";
 
 // Map of icon paths to their imported static assets
 const iconMap: Record<string, StaticImageData> = {
-  '/assets/icons/dashboard.svg': dashboardIcon,
-  '/assets/icons/documents.svg': documentsIcon,
-  '/assets/icons/images.svg': imagesIcon,
-  '/assets/icons/video.svg': videoIcon,
-  '/assets/icons/others.svg': othersIcon,
-  '/assets/icons/logout.svg': logoutIcon,
-  '/assets/icons/menu.svg': menuIcon,
+  "/assets/icons/dashboard.svg": dashboardIcon,
+  "/assets/icons/documents.svg": documentsIcon,
+  "/assets/icons/images.svg": imagesIcon,
+  "/assets/icons/video.svg": videoIcon,
+  "/assets/icons/others.svg": othersIcon,
+  "/assets/icons/logout.svg": logoutIcon,
+  "/assets/icons/menu.svg": menuIcon,
 };
 
-interface OptimizedIconProps extends Omit<ImageProps, 'src'> {
+interface OptimizedIconProps extends Omit<ImageProps, "src"> {
   src: string;
   isActive?: boolean;
 }
 
 // Optimized icon component that uses static imports when available
-const OptimizedIcon: React.FC<OptimizedIconProps> = ({ src, className, alt = 'icon', ...props }) => {
+const OptimizedIcon: React.FC<OptimizedIconProps> = ({
+  src,
+  className,
+  alt = "icon",
+  ...props
+}) => {
   // Use static import if available, otherwise use the path
   const iconSrc = iconMap[src] || src;
-  
+
   return (
     <Image
       src={iconSrc}

--- a/components/OptimizedNavigation.tsx
+++ b/components/OptimizedNavigation.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react';
-import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { cn } from '@/lib/utils';
-import { navItems } from '@/constants';
-import OptimizedIcon from './OptimizedIcon';
+import React, { useCallback, useMemo } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { navItems } from "@/constants";
+import OptimizedIcon from "./OptimizedIcon";
 
 interface NavItemProps {
   url: string;
@@ -14,37 +14,46 @@ interface NavItemProps {
 }
 
 // Highly optimized navigation item component
-const NavItem = React.memo(({ url, name, icon, isActive, onClick }: NavItemProps) => {
-  return (
-    <Link 
-      href={url} 
-      prefetch={true} 
-      onClick={onClick}
-      className="lg:w-full"
-    >
-      <li
-        className={cn(
-          "sidebar-nav-item",
-          isActive && "shad-active",
-        )}
-      >
-        <OptimizedIcon
-          src={icon}
-          alt={name}
-          width={24}
-          height={24}
-          className={cn(
-            "nav-icon",
-            isActive && "nav-icon-active",
+const NavItem = React.memo(
+  ({ url, name, icon, isActive, onClick }: NavItemProps) => {
+    return (
+      <Link href={url} prefetch={true} onClick={onClick} className="lg:w-full">
+        <li className={cn("sidebar-nav-item", isActive && "shad-active")}>
+          {name === "Profile" ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width={24}
+              height={24}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={cn("profile-icon", isActive && "profile-icon-active")}
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
+              <path d="M6.168 18.849a4 4 0 0 1 3.832 -2.849h4a4 4 0 0 1 3.834 2.855" />
+            </svg>
+          ) : (
+            <OptimizedIcon
+              src={icon}
+              alt={name}
+              width={24}
+              height={24}
+              className={cn("nav-icon", isActive && "nav-icon-active")}
+            />
           )}
-        />
-        <p className="hidden lg:block">{name}</p>
-      </li>
-    </Link>
-  );
-});
+          <p className="hidden lg:block">{name}</p>
+        </li>
+      </Link>
+    );
+  }
+);
 
-NavItem.displayName = 'NavItem';
+NavItem.displayName = "NavItem";
 
 interface OptimizedNavigationProps {
   className?: string;
@@ -52,9 +61,9 @@ interface OptimizedNavigationProps {
 }
 
 // Main navigation component with instant navigation
-const OptimizedNavigation: React.FC<OptimizedNavigationProps> = ({ 
+const OptimizedNavigation: React.FC<OptimizedNavigationProps> = ({
   className,
-  onItemClick = () => {}
+  onItemClick = () => {},
 }) => {
   const pathname = usePathname();
   const router = useRouter();
@@ -62,13 +71,13 @@ const OptimizedNavigation: React.FC<OptimizedNavigationProps> = ({
   // Preload all routes on component mount
   React.useEffect(() => {
     // Preload all routes
-    navItems.forEach(item => {
+    navItems.forEach((item) => {
       router.prefetch(item.url);
     });
 
     // Preload all images
     const preloadImages = () => {
-      navItems.forEach(item => {
+      navItems.forEach((item) => {
         const img = new Image();
         img.src = item.icon;
       });
@@ -77,21 +86,24 @@ const OptimizedNavigation: React.FC<OptimizedNavigationProps> = ({
   }, [router]);
 
   // Handle navigation click with client-side transition
-  const handleNavClick = useCallback((url: string) => {
-    return () => {
-      onItemClick();
-      router.push(url);
-    };
-  }, [onItemClick, router]);
+  const handleNavClick = useCallback(
+    (url: string) => {
+      return () => {
+        onItemClick();
+        router.push(url);
+      };
+    },
+    [onItemClick, router]
+  );
 
   // Memoize navigation items to prevent re-renders
   const navigationItems = useMemo(() => {
     return navItems.map(({ url, name, icon }) => (
-      <NavItem 
-        key={name} 
-        url={url} 
-        name={name} 
-        icon={icon} 
+      <NavItem
+        key={name}
+        url={url}
+        name={name}
+        icon={icon}
         isActive={pathname === url}
         onClick={handleNavClick(url)}
       />
@@ -100,9 +112,7 @@ const OptimizedNavigation: React.FC<OptimizedNavigationProps> = ({
 
   return (
     <nav className={className || "sidebar-nav"}>
-      <ul className="flex flex-1 flex-col gap-6">
-        {navigationItems}
-      </ul>
+      <ul className="flex flex-1 flex-col gap-6">{navigationItems}</ul>
     </nav>
   );
 };

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { updateUserProfile } from "@/lib/actions/user.actions";
+import { useToast } from "@/hooks/use-toast";
+import OptimizedIcon from "@/components/OptimizedIcon";
+
+interface ProfileFormProps {
+  user: {
+    $id: string;
+    fullName: string;
+    email: string;
+    avatar: string;
+    accountId: string;
+  };
+}
+
+const ProfileForm = ({ user }: ProfileFormProps) => {
+  const [fullName, setFullName] = useState(user.fullName);
+  const [avatar, setAvatar] = useState(user.avatar);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const { toast } = useToast();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      // Create preview URL
+      const previewUrl = URL.createObjectURL(file);
+      setAvatar(previewUrl);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      await updateUserProfile({
+        userId: user.$id,
+        fullName,
+        avatar: selectedFile || avatar,
+      });
+
+      toast({
+        title: "Success",
+        description: "Profile updated successfully",
+      });
+    } catch (error) {
+      console.error("Profile update error:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update profile",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg border p-6 max-w-2xl">
+      <h2 className="text-xl font-semibold mb-6">Personal Information</h2>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Profile Photo Section */}
+        <div className="flex items-start gap-4">
+          <div className="relative">
+            <div className="w-20 h-20 rounded-full bg-gray-200 overflow-hidden">
+              <Image
+                src={avatar}
+                alt="Profile"
+                width={80}
+                height={80}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <label className="absolute bottom-0 right-0 bg-blue-500 rounded-full p-2 cursor-pointer hover:bg-blue-600 transition-colors">
+              <OptimizedIcon
+                src="/assets/icons/camera.svg"
+                alt="Upload"
+                width={16}
+                height={16}
+                className="text-white"
+              />
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </label>
+          </div>
+          <div>
+            <h3 className="font-medium">Profile Photo</h3>
+            <p className="text-sm text-gray-500">
+              Click the camera icon to upload a new photo
+            </p>
+          </div>
+        </div>
+
+        {/* Full Name Field */}
+        <div className="space-y-2">
+          <Label htmlFor="fullName">Full Name</Label>
+          <Input
+            id="fullName"
+            type="text"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            className="w-full"
+            required
+          />
+        </div>
+
+        {/* Email Field (Read-only) */}
+        <div className="space-y-2">
+          <Label htmlFor="email">Email Address</Label>
+          <div className="relative">
+            <Input
+              id="email"
+              type="email"
+              value={user.email}
+              className="w-full pr-10 bg-gray-50"
+              readOnly
+            />
+            <OptimizedIcon
+              src="/assets/icons/email.svg"
+              alt="Email"
+              width={20}
+              height={20}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+            />
+          </div>
+          <p className="text-sm text-orange-500">
+            Email address cannot be changed
+          </p>
+        </div>
+
+        {/* Save Button */}
+        <div className="flex justify-end pt-4">
+          <Button
+            type="submit"
+            disabled={isLoading}
+            className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2"
+          >
+            {isLoading ? "Saving..." : "Save Changes"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ProfileForm;

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -8,23 +8,17 @@ import { Label } from "@/components/ui/label";
 import { updateUserProfile } from "@/lib/actions/user.actions";
 import { useToast } from "@/hooks/use-toast";
 import OptimizedIcon from "@/components/OptimizedIcon";
+import { useUser } from "@/contexts/UserContext";
 
-interface ProfileFormProps {
-  user: {
-    $id: string;
-    fullName: string;
-    email: string;
-    avatar: string;
-    accountId: string;
-  };
-}
-
-const ProfileForm = ({ user }: ProfileFormProps) => {
-  const [fullName, setFullName] = useState(user.fullName);
-  const [avatar, setAvatar] = useState(user.avatar);
+const ProfileForm = () => {
+  const { user, updateUser } = useUser();
+  const [fullName, setFullName] = useState(user?.fullName || "");
+  const [avatar, setAvatar] = useState(user?.avatar || "");
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const { toast } = useToast();
+
+  if (!user) return null;
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -41,11 +35,19 @@ const ProfileForm = ({ user }: ProfileFormProps) => {
     setIsLoading(true);
 
     try {
-      await updateUserProfile({
+      const updatedUser = await updateUserProfile({
         userId: user.$id,
         fullName,
         avatar: selectedFile || avatar,
       });
+
+      // Update the user context with new data
+      if (updatedUser) {
+        updateUser({
+          fullName: updatedUser.fullName,
+          avatar: updatedUser.avatar,
+        });
+      }
 
       toast({
         title: "Success",
@@ -93,6 +95,9 @@ const ProfileForm = ({ user }: ProfileFormProps) => {
                 accept="image/*"
                 onChange={handleFileChange}
                 className="hidden"
+                title="Upload profile photo"
+                placeholder="Upload profile photo"
+                aria-label="Upload profile photo"
               />
             </label>
           </div>
@@ -146,7 +151,7 @@ const ProfileForm = ({ user }: ProfileFormProps) => {
           <Button
             type="submit"
             disabled={isLoading}
-            className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2"
+            className="bg-brand hover:bg-blue rounded-full px-6 py-5"
           >
             {isLoading ? "Saving..." : "Save Changes"}
           </Button>

--- a/components/RecentFileRow.tsx
+++ b/components/RecentFileRow.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Models } from "node-appwrite";
+import { useFileViewer } from "@/components/FileViewerProvider";
+import Thumbnail from "@/components/Thumbnail";
+import FormattedDateTime from "@/components/FormattedDateTime";
+import ActionDropdown from "@/components/ActionDropdown";
+
+const RecentFileRow = ({ file, index }: { file: Models.Document; index: number }) => {
+  const { open } = useFileViewer();
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={() => open(index)}
+        className="flex flex-1 items-center gap-3 text-left"
+      >
+        <Thumbnail type={file.type} extension={file.extension} url={file.url} />
+        <div className="flex flex-col gap-1">
+          <p className="recent-file-name">{file.name}</p>
+          <FormattedDateTime date={file.$createdAt} className="caption" />
+        </div>
+      </button>
+      <ActionDropdown file={file} />
+    </div>
+  );
+};
+
+export default RecentFileRow;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 import Image from "next/image";
 import { memo } from "react";
 import OptimizedNavigation from "./OptimizedNavigation";
+import { useUser } from "@/contexts/UserContext";
 
-interface Props {
-  fullName: string;
-  avatar: string;
-  email: string;
-}
+const Sidebar = () => {
+  const { user } = useUser();
 
-const Sidebar = ({ fullName, avatar, email }: Props) => {
+  if (!user) return null;
+
+  const { fullName, avatar, email } = user;
   return (
     <aside className="sidebar">
       <Link href="/">

--- a/components/SignOutButton.tsx
+++ b/components/SignOutButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { signOutUser } from "@/lib/actions/user.actions";
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+
+const SignOutButton = ({ className }: { className?: string }) => {
+  const handleClick = async () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("loggedIn");
+    }
+    await signOutUser();
+  };
+
+  return (
+    <Button type="button" className={className} onClick={handleClick}>
+      <Image
+        src="/assets/icons/logout.svg"
+        alt="logout"
+        width={24}
+        height={24}
+        className="w-6"
+      />
+    </Button>
+  );
+};
+
+export default SignOutButton;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -29,6 +29,12 @@ export const navItems = [
     url: "/others",
     prefetch: true,
   },
+  {
+    name: "Profile",
+    icon: "/assets/icons/user.svg",
+    url: "/profile",
+    prefetch: true,
+  },
 ];
 
 export const actionsDropdownItems = [

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+interface User {
+  $id: string;
+  fullName: string;
+  email: string;
+  avatar: string;
+  accountId: string;
+}
+
+interface UserContextType {
+  user: User | null;
+  updateUser: (userData: Partial<User>) => void;
+  setUser: (user: User) => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({
+  children,
+  initialUser,
+}: {
+  children: ReactNode;
+  initialUser: User;
+}) => {
+  const [user, setUserState] = useState<User | null>(initialUser);
+
+  const updateUser = (userData: Partial<User>) => {
+    if (user) {
+      setUserState({ ...user, ...userData });
+    }
+  };
+
+  const setUser = (newUser: User) => {
+    setUserState(newUser);
+  };
+
+  return (
+    <UserContext.Provider value={{ user, updateUser, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useUser must be used within a UserProvider");
+  }
+  return context;
+};
+
+export default UserContext;

--- a/lib/actions/file.actions.ts
+++ b/lib/actions/file.actions.ts
@@ -193,6 +193,22 @@ export const deleteFile = async ({
   }
 };
 
+export const getFileById = async ({ fileId }: { fileId: string }) => {
+  const { databases } = await createAdminClient();
+
+  try {
+    const file = await databases.getDocument(
+      appwriteConfig.databaseId,
+      appwriteConfig.filesCollectionId,
+      fileId,
+    );
+
+    return parseStringify(file);
+  } catch (error) {
+    handleError(error, "Failed to get file by id");
+  }
+};
+
 // ============================== TOTAL FILE SPACE USED
 export async function getTotalSpaceUsed() {
   try {

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -85,6 +85,8 @@ export const verifySecret = async ({
       httpOnly: true,
       sameSite: "strict",
       secure: true,
+      maxAge: 60 * 60 * 24 * 30, // persist cookie for 30 days
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
     });
 
     return parseStringify({ sessionId: session.$id });

--- a/lib/appwrite/index.ts
+++ b/lib/appwrite/index.ts
@@ -24,6 +24,9 @@ export const createSessionClient = async () => {
     get databases() {
       return new Databases(client);
     },
+    get storage() {
+      return new Storage(client);
+    },
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "19.0.0-rc-02c0e824-20241028",
         "react-dropzone": "^14.3.5",
         "react-hook-form": "^7.53.1",
+        "react-icons": "^5.5.0",
         "recharts": "^2.13.3",
         "tailwind-merge": "^2.5.4",
         "use-debounce": "^10.0.4",
@@ -194,6 +195,10 @@
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "resolved": "node_modules/eslint/@eslint/config-array",
+      "link": true
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -3796,10 +3801,6 @@
     "node_modules/eslint/@eslint/config-array": {
       "dev": true
     },
-    "node_modules/eslint/node_modules/@humanwhocodes/config-array": {
-      "resolved": "node_modules/eslint/@eslint/config-array",
-      "link": true
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -5903,6 +5904,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "input-otp": "^1.2.5",
+    "lru-cache": "^10.2.0",
     "lucide-react": "^0.454.0",
     "next": "15.0.2",
     "node-appwrite": "^14.1.0",
@@ -29,11 +30,11 @@
     "react-dom": "19.0.0-rc-02c0e824-20241028",
     "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.53.1",
+    "react-icons": "^5.5.0",
     "recharts": "^2.13.3",
     "tailwind-merge": "^2.5.4",
     "use-debounce": "^10.0.4",
-    "zod": "^3.23.8",
-    "lru-cache": "^10.2.0"
+    "zod": "^3.23.8"
   },
   "overrides": {
     "react": "$react",

--- a/public/assets/icons/camera.svg
+++ b/public/assets/icons/camera.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23 19C23 19.5304 22.7893 20.0391 22.4142 20.4142C22.0391 20.7893 21.5304 21 21 21H3C2.46957 21 1.96086 20.7893 1.58579 20.4142C1.21071 20.0391 1 19.5304 1 19V8C1 7.46957 1.21071 6.96086 1.58579 6.58579C1.96086 6.21071 2.46957 6 3 6H7L9 3H15L17 6H21C21.5304 6 22.0391 6.21071 22.4142 6.58579C22.7893 6.96086 23 7.46957 23 8V19Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="12" cy="13" r="4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icons/email.svg
+++ b/public/assets/icons/email.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 4H20C21.1 4 22 4.9 22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6C2 4.9 2.9 4 4 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="22,6 12,13 2,6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icons/user.svg
+++ b/public/assets/icons/user.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.59 22C20.59 18.13 16.74 15 12 15C7.26 15 3.41 18.13 3.41 22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icons/user.svg
+++ b/public/assets/icons/user.svg
@@ -1,4 +1,1 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M20.59 22C20.59 18.13 16.74 15 12 15C7.26 15 3.41 18.13 3.41 22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-user-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M6.168 18.849a4 4 0 0 1 3.832 -2.849h4a4 4 0 0 1 3.834 2.855" /></svg>


### PR DESCRIPTION
## Summary
- add persistent session cookie
- set localStorage flag on login and remove on logout
- add `SignOutButton` client component
- update header and mobile navigation to use new sign-out logic
- add `FileViewer` component with previous/next navigation
- create file viewer route and link cards/dashboard to it

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6840d8a8c5fc832db37448bcd91b81b2