### PR TITLE
feat: add secure file sharing metadata and routes

### DIFF
--- a/app/(root)/share/[token]/page.tsx
+++ b/app/(root)/share/[token]/page.tsx
@@ -1,0 +1,44 @@
+import FileViewer from "@/components/FileViewer";
+import { getFileByShareToken } from "@/lib/actions/file.actions";
+import { constructDownloadUrl } from "@/lib/utils";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const SharePage = async ({ params }: { params: { token: string } }) => {
+  const file = await getFileByShareToken(params.token);
+
+  if (!file) {
+    notFound();
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center gap-6 p-6">
+      <div className="w-full max-w-5xl space-y-6">
+        <h1 className="text-center text-2xl font-semibold text-light-100">
+          {file.name}
+        </h1>
+
+        <div className="rounded-2xl bg-dark-400/40 p-4 shadow-lg">
+          <FileViewer file={file} shareToken={params.token} />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button asChild className="modal-submit-button">
+            <Link href={constructDownloadUrl(file.bucketField, params.token)}>
+              Download file
+            </Link>
+          </Button>
+          <Link
+            href="/"
+            className="text-sm text-light-300 underline-offset-4 hover:underline"
+          >
+            Go to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SharePage;

--- a/app/api/files/[fileId]/download/route.ts
+++ b/app/api/files/[fileId]/download/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeFileAccess, buildAppwriteUrl } from "../helpers";
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: { fileId: string } },
+) => {
+  const token = request.nextUrl.searchParams.get("token");
+  const result = await authorizeFileAccess(params.fileId, token);
+
+  if (!result.authorized) {
+    const status = result.status ?? 403;
+    return NextResponse.json(
+      { error: result.message ?? "Unauthorized" },
+      { status },
+    );
+  }
+
+  const url = buildAppwriteUrl(params.fileId, "download");
+  return NextResponse.redirect(url);
+};

--- a/app/api/files/[fileId]/helpers.ts
+++ b/app/api/files/[fileId]/helpers.ts
@@ -54,10 +54,12 @@ export const authorizeFileAccess = async (
   }
 
   const ownerId = extractOwnerId(file.owner);
-  const sharedEmails = Array.isArray(file.sharedEmails)
-    ? file.sharedEmails
-    : Array.isArray(file.users)
-      ? file.users
+  const sharedEmails = Array.isArray(file.users)
+    ? file.users
+    : Array.isArray(file.sharedWith)
+      ? file.sharedWith
+          .map((invite: { email?: string }) => invite?.email)
+          .filter((email: string | undefined): email is string => !!email)
       : [];
 
   const isOwner = currentUser && ownerId && ownerId === currentUser.$id;

--- a/app/api/files/[fileId]/helpers.ts
+++ b/app/api/files/[fileId]/helpers.ts
@@ -67,7 +67,6 @@ export const authorizeFileAccess = async (
 
   const hasValidToken =
     !!token &&
-    file.isPublic &&
     file.shareToken === token &&
     (!file.shareExpiresAt || new Date(file.shareExpiresAt) > new Date());
 

--- a/app/api/files/[fileId]/helpers.ts
+++ b/app/api/files/[fileId]/helpers.ts
@@ -1,0 +1,77 @@
+import { createAdminClient } from "@/lib/appwrite";
+import { appwriteConfig } from "@/lib/appwrite/config";
+import { getCurrentUser } from "@/lib/actions/user.actions";
+import { Query } from "node-appwrite";
+
+const extractOwnerId = (owner: any): string | null => {
+  if (!owner) return null;
+
+  if (typeof owner === "string") return owner;
+
+  if (typeof owner === "object") {
+    if (typeof owner.$id === "string") return owner.$id;
+    if (typeof owner.ownerId === "string") return owner.ownerId;
+    if (typeof owner.accountId === "string") return owner.accountId;
+  }
+
+  return null;
+};
+
+export const buildAppwriteUrl = (fileId: string, mode: "view" | "download") => {
+  return `${appwriteConfig.endpointUrl}/storage/buckets/${appwriteConfig.bucketId}/files/${fileId}/${mode}?project=${appwriteConfig.projectId}`;
+};
+
+interface AuthorizationResult {
+  authorized: boolean;
+  status?: number;
+  message?: string;
+  file?: any;
+}
+
+export const authorizeFileAccess = async (
+  fileId: string,
+  token?: string | null,
+): Promise<AuthorizationResult> => {
+  const { databases } = await createAdminClient();
+
+  const files = await databases.listDocuments(
+    appwriteConfig.databaseId,
+    appwriteConfig.filesCollectionId,
+    [Query.equal("bucketField", [fileId]), Query.limit(1)],
+  );
+
+  if (files.total === 0) {
+    return { authorized: false, status: 404, message: "File not found" };
+  }
+
+  const file = files.documents[0];
+
+  let currentUser = null;
+  try {
+    currentUser = await getCurrentUser();
+  } catch (error) {
+    currentUser = null;
+  }
+
+  const ownerId = extractOwnerId(file.owner);
+  const sharedEmails = Array.isArray(file.sharedEmails)
+    ? file.sharedEmails
+    : Array.isArray(file.users)
+      ? file.users
+      : [];
+
+  const isOwner = currentUser && ownerId && ownerId === currentUser.$id;
+  const isSharedUser = currentUser && sharedEmails.includes(currentUser.email);
+
+  const hasValidToken =
+    !!token &&
+    file.isPublic &&
+    file.shareToken === token &&
+    (!file.shareExpiresAt || new Date(file.shareExpiresAt) > new Date());
+
+  if (!isOwner && !isSharedUser && !hasValidToken) {
+    return { authorized: false, status: 403, message: "Unauthorized" };
+  }
+
+  return { authorized: true, file };
+};

--- a/app/api/files/[fileId]/view/route.ts
+++ b/app/api/files/[fileId]/view/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeFileAccess, buildAppwriteUrl } from "../helpers";
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: { fileId: string } },
+) => {
+  const token = request.nextUrl.searchParams.get("token");
+  const result = await authorizeFileAccess(params.fileId, token);
+
+  if (!result.authorized) {
+    const status = result.status ?? 403;
+    return NextResponse.json(
+      { error: result.message ?? "Unauthorized" },
+      { status },
+    );
+  }
+
+  const url = buildAppwriteUrl(params.fileId, "view");
+  return NextResponse.redirect(url);
+};

--- a/components/ActionDropdown.tsx
+++ b/components/ActionDropdown.tsx
@@ -60,7 +60,6 @@ const ActionDropdown = ({ file }: { file: Models.Document }) => {
 
     return [];
   });
-  const [isPublic, setIsPublic] = useState<boolean>(Boolean(file.isPublic));
   const [shareExpiresAt, setShareExpiresAt] = useState<string | null>(
     file.shareExpiresAt ?? null,
   );
@@ -93,7 +92,6 @@ const ActionDropdown = ({ file }: { file: Models.Document }) => {
 
     setInvites(initialInvites);
     const token = (file.shareToken as string) ?? null;
-    setIsPublic(Boolean(file.isPublic));
     setShareExpiresAt((file.shareExpiresAt as string) ?? null);
     setShareLink(token ? buildShareLink(token) : "");
     setNewInviteEmail("");
@@ -140,7 +138,6 @@ const ActionDropdown = ({ file }: { file: Models.Document }) => {
       : [];
     setInvites(nextInvites);
     const token = (doc.shareToken as string) ?? null;
-    setIsPublic(Boolean(doc.isPublic));
     setShareExpiresAt((doc.shareExpiresAt as string) ?? null);
     setShareLink(token ? buildShareLink(token) : "");
   };
@@ -291,7 +288,6 @@ const ActionDropdown = ({ file }: { file: Models.Document }) => {
             <FileShareSettings
               file={file}
               shareLink={shareLink}
-              isPublic={isPublic}
               shareExpiresAt={shareExpiresAt}
               expirationOption={expirationOption}
               onExpirationChange={setExpirationOption}

--- a/components/ActionsModalContent.tsx
+++ b/components/ActionsModalContent.tsx
@@ -5,6 +5,14 @@ import { convertFileSize, formatDateTime } from "@/lib/utils";
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import Image from "next/image";
 
 const ImageThumbnail = ({ file }: { file: Models.Document }) => (
@@ -90,6 +98,229 @@ export const ShareInput = ({ file, onInputChange, onRemove }: Props) => {
             ))}
           </ul>
         </div>
+      </div>
+    </>
+  );
+};
+
+type ShareExpirationOption = "24h" | "7d" | "30d" | "never";
+
+interface FileShareSettingsProps {
+  file: Models.Document;
+  shareLink: string;
+  isPublic: boolean;
+  shareExpiresAt: string | null;
+  expirationOption: ShareExpirationOption;
+  onExpirationChange: (value: ShareExpirationOption) => void;
+  onGenerateLink: () => void;
+  onRevokeLink: () => void;
+  onCopyLink: () => void;
+  invites: ShareInvitee[];
+  newInviteEmail: string;
+  newInviteRole: ShareRole;
+  onNewInviteEmailChange: (value: string) => void;
+  onNewInviteRoleChange: (role: ShareRole) => void;
+  onAddInvite: () => void;
+  onInviteRoleChange: (email: string, role: ShareRole) => void;
+  onRemoveInvite: (email: string) => void;
+  isGeneratingLink?: boolean;
+  isRevokingLink?: boolean;
+  isInviteLoading?: boolean;
+  roleUpdatingEmail?: string | null;
+  copyLabel?: string;
+  expiresLabel?: string;
+}
+
+const roleOptions: { label: string; value: ShareRole }[] = [
+  { label: "Viewer", value: "viewer" },
+  { label: "Editor", value: "editor" },
+];
+
+const expirationOptions: { label: string; value: ShareExpirationOption }[] = [
+  { label: "24 hours", value: "24h" },
+  { label: "7 days", value: "7d" },
+  { label: "30 days", value: "30d" },
+  { label: "Never", value: "never" },
+];
+
+export const FileShareSettings = ({
+  file,
+  shareLink,
+  isPublic,
+  shareExpiresAt,
+  expirationOption,
+  onExpirationChange,
+  onGenerateLink,
+  onRevokeLink,
+  onCopyLink,
+  invites,
+  newInviteEmail,
+  newInviteRole,
+  onNewInviteEmailChange,
+  onNewInviteRoleChange,
+  onAddInvite,
+  onInviteRoleChange,
+  onRemoveInvite,
+  isGeneratingLink = false,
+  isRevokingLink = false,
+  isInviteLoading = false,
+  roleUpdatingEmail,
+  copyLabel = "Copy link",
+  expiresLabel,
+}: FileShareSettingsProps) => {
+  const isExpired = shareExpiresAt
+    ? new Date(shareExpiresAt) < new Date()
+    : false;
+
+  return (
+    <>
+      <ImageThumbnail file={file} />
+      <div className="share-wrapper space-y-6">
+        <section className="space-y-3">
+          <p className="subtitle-2 pl-1 text-light-100">Share link</p>
+          {isPublic && shareLink ? (
+            <div className="space-y-3">
+              <div className="flex flex-col gap-2 md:flex-row">
+                <Input value={shareLink} readOnly className="share-input-field flex-1" />
+                <div className="flex flex-col gap-2 md:flex-row">
+                  <Button
+                    onClick={onCopyLink}
+                    className="modal-submit-button whitespace-nowrap"
+                    disabled={!shareLink}
+                  >
+                    {copyLabel}
+                  </Button>
+                  <Button
+                    onClick={onRevokeLink}
+                    disabled={isRevokingLink}
+                    variant="secondary"
+                    className="modal-cancel-button whitespace-nowrap"
+                  >
+                    {isRevokingLink ? "Revoking..." : "Revoke"}
+                  </Button>
+                </div>
+              </div>
+              <p className="caption text-light-200">
+                {expiresLabel}
+                {isExpired ? " (expired)" : ""}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <Select
+                  value={expirationOption}
+                  onValueChange={(value) =>
+                    onExpirationChange(value as ShareExpirationOption)
+                  }
+                >
+                  <SelectTrigger className="share-input-field">
+                    <SelectValue placeholder="Choose expiration" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {expirationOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                onClick={onGenerateLink}
+                className="modal-submit-button"
+                disabled={isGeneratingLink}
+              >
+                {isGeneratingLink ? "Generating..." : "Generate link"}
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <Separator className="opacity-40" />
+
+        <section className="space-y-3">
+          <p className="subtitle-2 pl-1 text-light-100">Invite collaborators</p>
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
+            <Input
+              type="email"
+              value={newInviteEmail}
+              placeholder="Enter email address"
+              onChange={(event) => onNewInviteEmailChange(event.target.value)}
+              className="share-input-field md:flex-1"
+            />
+            <Select
+              value={newInviteRole}
+              onValueChange={(value) => onNewInviteRoleChange(value as ShareRole)}
+            >
+              <SelectTrigger className="md:w-[140px]">
+                <SelectValue placeholder="Role" />
+              </SelectTrigger>
+              <SelectContent>
+                {roleOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              onClick={onAddInvite}
+              className="modal-submit-button whitespace-nowrap"
+              disabled={isInviteLoading || !newInviteEmail}
+            >
+              {isInviteLoading ? "Saving..." : "Add"}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {invites.length === 0 ? (
+              <p className="caption text-light-200">
+                No collaborators have been added yet.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {invites.map((invite) => (
+                  <li
+                    key={invite.email}
+                    className="flex flex-col gap-2 rounded-lg border border-dashed border-light-400 px-3 py-2 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <p className="subtitle-2">{invite.email}</p>
+                    </div>
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                      <Select
+                        value={invite.role}
+                        onValueChange={(value) =>
+                          onInviteRoleChange(invite.email, value as ShareRole)
+                        }
+                        disabled={roleUpdatingEmail === invite.email}
+                      >
+                        <SelectTrigger className="md:w-[140px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roleOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        onClick={() => onRemoveInvite(invite.email)}
+                        className="modal-cancel-button"
+                        variant="secondary"
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
       </div>
     </>
   );

--- a/components/ActionsModalContent.tsx
+++ b/components/ActionsModalContent.tsx
@@ -108,7 +108,6 @@ type ShareExpirationOption = "24h" | "7d" | "30d" | "never";
 interface FileShareSettingsProps {
   file: Models.Document;
   shareLink: string;
-  isPublic: boolean;
   shareExpiresAt: string | null;
   expirationOption: ShareExpirationOption;
   onExpirationChange: (value: ShareExpirationOption) => void;
@@ -146,7 +145,6 @@ const expirationOptions: { label: string; value: ShareExpirationOption }[] = [
 export const FileShareSettings = ({
   file,
   shareLink,
-  isPublic,
   shareExpiresAt,
   expirationOption,
   onExpirationChange,
@@ -178,7 +176,7 @@ export const FileShareSettings = ({
       <div className="share-wrapper space-y-6">
         <section className="space-y-3">
           <p className="subtitle-2 pl-1 text-light-100">Share link</p>
-          {isPublic && shareLink ? (
+          {shareLink ? (
             <div className="space-y-3">
               <div className="flex flex-col gap-2 md:flex-row">
                 <Input value={shareLink} readOnly className="share-input-field flex-1" />

--- a/lib/actions/file.actions.ts
+++ b/lib/actions/file.actions.ts
@@ -42,7 +42,6 @@ export const uploadFile = async ({
       folderId,
       users: [],
       sharedWith: [],
-      isPublic: false,
       shareToken: null,
       shareExpiresAt: null,
       bucketField: bucketFile.$id,
@@ -215,7 +214,6 @@ export const createFileShareLink = async ({
       appwriteConfig.filesCollectionId,
       fileId,
       {
-        isPublic: true,
         shareToken: ID.unique(),
         shareExpiresAt: expiresAt ?? null,
       },
@@ -240,7 +238,6 @@ export const revokeFileShareLink = async ({
       appwriteConfig.filesCollectionId,
       fileId,
       {
-        isPublic: false,
         shareToken: null,
         shareExpiresAt: null,
       },
@@ -344,7 +341,6 @@ export const getFileByShareToken = async (token: string) => {
       appwriteConfig.filesCollectionId,
       [
         Query.equal("shareToken", [token]),
-        Query.equal("isPublic", [true]),
         Query.limit(1),
       ],
     );

--- a/lib/actions/file.actions.ts
+++ b/lib/actions/file.actions.ts
@@ -42,7 +42,6 @@ export const uploadFile = async ({
       folderId,
       users: [],
       sharedWith: [],
-      sharedEmails: [],
       isPublic: false,
       shareToken: null,
       shareExpiresAt: null,
@@ -79,7 +78,6 @@ const createQueries = (
   const queries = [
     Query.or([
       Query.equal("owner", [currentUser.$id]),
-      Query.contains("sharedEmails", [currentUser.email]),
       Query.contains("users", [currentUser.email]),
     ]),
   ];
@@ -193,7 +191,6 @@ export const updateFileInvites = async ({
       fileId,
       {
         sharedWith: normalizedInvites,
-        sharedEmails: emails,
         users: emails,
       },
     );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -178,12 +178,35 @@ export const getFileIcon = (
 
 // APPWRITE URL UTILS
 // Construct appwrite file URL - https://appwrite.io/docs/apis/rest#images
-export const constructFileUrl = (bucketFileId: string) => {
-  return `${process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT}/storage/buckets/${process.env.NEXT_PUBLIC_APPWRITE_BUCKET}/files/${bucketFileId}/view?project=${process.env.NEXT_PUBLIC_APPWRITE_PROJECT}`;
+const constructSecureRoute = (
+  bucketFileId: string,
+  mode: "view" | "download",
+  token?: string,
+) => {
+  const base = `/api/files/${bucketFileId}/${mode}`;
+  return token ? `${base}?token=${token}` : base;
 };
 
-export const constructDownloadUrl = (bucketFileId: string) => {
-  return `${process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT}/storage/buckets/${process.env.NEXT_PUBLIC_APPWRITE_BUCKET}/files/${bucketFileId}/download?project=${process.env.NEXT_PUBLIC_APPWRITE_PROJECT}`;
+export const constructFileUrl = (bucketFileId: string, token?: string) => {
+  return constructSecureRoute(bucketFileId, "view", token);
+};
+
+export const constructDownloadUrl = (bucketFileId: string, token?: string) => {
+  return constructSecureRoute(bucketFileId, "download", token);
+};
+
+export const buildShareLink = (token: string) => {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (appUrl) {
+    const normalized = appUrl.endsWith("/") ? appUrl.slice(0, -1) : appUrl;
+    return `${normalized}/share/${token}`;
+  }
+
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}/share/${token}`;
+  }
+
+  return `/share/${token}`;
 };
 
 // Check if files contain folder structure (webkitRelativePath)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,9 +39,34 @@ declare interface RenameFileProps {
   extension: string;
   path: string;
 }
-declare interface UpdateFileUsersProps {
+declare type ShareRole = "viewer" | "editor";
+
+declare interface ShareInvitee {
+  email: string;
+  role: ShareRole;
+}
+
+declare interface UpdateFileInvitesProps {
   fileId: string;
-  emails: string[];
+  invites: ShareInvitee[];
+  path: string;
+}
+
+declare interface CreateShareLinkProps {
+  fileId: string;
+  expiresAt?: string | null;
+  path: string;
+}
+
+declare interface RevokeShareLinkProps {
+  fileId: string;
+  path: string;
+}
+
+declare interface SetInviteeRoleProps {
+  fileId: string;
+  email: string;
+  role: ShareRole;
   path: string;
 }
 declare interface DeleteFileProps {


### PR DESCRIPTION
## Summary
- track sharing metadata on file documents and expose server actions to manage invitations and share links
- secure file delivery behind Next.js route handlers and surface a public share page for token-based access
- refresh the file share modal and viewer UI to copy share links, set expirations, and assign collaborator roles

## Testing
- npm run lint *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_6902d9d0eaf4832db2fd69c913604e2f